### PR TITLE
Add hook support for generating and validating nonce on Oauth handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,48 @@ const afterAuth = async(req, res, accessToken) => {
     shop,
     ...
   );
-  
+
   // the subscriptionUrl overrides redirecting to the HOME_PATH
   return subscriptionUrl;
 };
 
 export default handleAuthCallback(afterAuth);
+```
+
+#### Validating Nonce during OAuth handshake.
+
+It is recommended that you use and validate a state parameter (also called a nonce) during the OAuth handshake. By default, `handleAuthStart` generates a random string, but does not verify it. You should consider implementing your own generation and verification for the nonce.
+
+Read more about nonce verification on the [Shopify Authentication Docs](https://shopify.dev/tutorials/authenticate-with-oauth) and the state parameter on the [OAuth 2 RFC](https://datatracker.ietf.org/doc/html/rfc6819#section-3.6).
+
+To generate your own nonce, provide an async function as an option to `handleAuthStart`:
+
+```javascript
+import { handleAuthStart } from 'shopify-nextjs-toolbox';
+
+const generateNonce = async (req) => {
+  console.log("generating nonce");
+  return 'my-generated-nonce'; //eg. create uniq id in database
+};
+
+export default handleAuthStart({generateNonce});
+```
+
+To validate the nonce on the callback, provide an async function as an option to `handleAuthCallback`:
+
+```javascript
+import { handleAuthCallback } from 'shopify-nextjs-toolbox';
+
+const afterAuth = async(req, res, accessToken) => {
+ ...
+};
+
+const validateNonce = async (nonce, req) => {
+  console.log("validating nonce");
+  return nonce === 'my-generated-nonce'; //eg. validate and remove from database
+}
+
+export default handleAuthCallback(afterAuth, { validateNonce })
 ```
 
 ### Client Side

--- a/lib/middleware/oauth/handleAuthCallback.js
+++ b/lib/middleware/oauth/handleAuthCallback.js
@@ -17,10 +17,10 @@ var _verifyHmac = _interopRequireDefault(require("./verifyHmac"));
 
 var _exchangeAccessToken = _interopRequireDefault(require("./exchangeAccessToken"));
 
-var _default = function _default(handler) {
+var _default = function _default(handler, options) {
   return /*#__PURE__*/function () {
     var _ref = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee(req, res) {
-      var valid, accessTokenQuery, accessToken, redirectUrl;
+      var valid, validateNonce, validNonce, accessTokenQuery, accessToken, redirectUrl;
       return _regenerator["default"].wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -39,43 +39,76 @@ var _default = function _default(handler) {
               return _context.abrupt("return");
 
             case 5:
+              validateNonce = options && options.validateNonce;
+
+              if (!validateNonce) {
+                _context.next = 12;
+                break;
+              }
+
+              _context.next = 9;
+              return validateNonce(req.query.state, req);
+
+            case 9:
+              _context.t0 = _context.sent;
+              _context.next = 13;
+              break;
+
+            case 12:
+              _context.t0 = true;
+
+            case 13:
+              validNonce = _context.t0;
+
+              if (validNonce) {
+                _context.next = 18;
+                break;
+              }
+
+              res.statusCode = 403;
+              res.end(JSON.stringify({
+                message: "Invalid Nonce."
+              }));
+              return _context.abrupt("return");
+
+            case 18:
               accessTokenQuery = _querystring["default"].stringify({
                 code: req.query.code,
                 client_id: process.env.SHOPIFY_API_PUBLIC_KEY,
                 client_secret: process.env.SHOPIFY_API_PRIVATE_KEY
               });
-              _context.prev = 6;
-              _context.next = 9;
+              _context.prev = 19;
+              _context.next = 22;
               return (0, _exchangeAccessToken["default"])(req.query.shop, accessTokenQuery);
 
-            case 9:
+            case 22:
               accessToken = _context.sent;
-              _context.next = 12;
+              _context.next = 25;
               return handler(req, res, accessToken);
 
-            case 12:
+            case 25:
               redirectUrl = _context.sent;
               // finished with oauth! Redirect to home page or the custom URL provided by the handler
               res.redirect("".concat(redirectUrl || process.env.HOME_PATH, "?shop=").concat(req.query.shop));
-              _context.next = 21;
+              _context.next = 34;
               break;
 
-            case 16:
-              _context.prev = 16;
-              _context.t0 = _context["catch"](6);
-              console.log(_context.t0);
+            case 29:
+              _context.prev = 29;
+              _context.t1 = _context["catch"](19);
+              console.log(_context.t1);
               res.status(401).json({
                 message: "Error while retrieving access token.",
-                error: _context.t0
+                error: _context.t1
               });
               return _context.abrupt("return");
 
-            case 21:
+            case 34:
             case "end":
               return _context.stop();
           }
         }
-      }, _callee, null, [[6, 16]]);
+      }, _callee, null, [[19, 29]]);
     }));
 
     return function (_x, _x2) {

--- a/lib/middleware/oauth/handleAuthCallback.test.js
+++ b/lib/middleware/oauth/handleAuthCallback.test.js
@@ -27,7 +27,8 @@ var req = _nodeMocksHttp["default"].createRequest({
 });
 
 var res = {
-  redirect: jest.fn()
+  redirect: jest.fn(),
+  end: jest.fn()
 };
 describe('Handling the Shopify OAuth callback response', function () {
   var OLD_ENV = process.env;
@@ -41,12 +42,96 @@ describe('Handling the Shopify OAuth callback response', function () {
   afterAll(function () {
     process.env = OLD_ENV; // Restore old environment
   });
-  test('it redirects to the HOME_PATH by default', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee() {
-    return _regenerator["default"].wrap(function _callee$(_context) {
+  test('it fails if validateNonce fails', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee2() {
+    return _regenerator["default"].wrap(function _callee2$(_context2) {
       while (1) {
-        switch (_context.prev = _context.next) {
+        switch (_context2.prev = _context2.next) {
           case 0:
-            _context.next = 2;
+            _context2.next = 2;
+            return (0, _handleAuthCallback["default"])(function (req, res) {}, {
+              validateNonce: function () {
+                var _validateNonce = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee() {
+                  return _regenerator["default"].wrap(function _callee$(_context) {
+                    while (1) {
+                      switch (_context.prev = _context.next) {
+                        case 0:
+                          return _context.abrupt("return", false);
+
+                        case 1:
+                        case "end":
+                          return _context.stop();
+                      }
+                    }
+                  }, _callee);
+                }));
+
+                function validateNonce() {
+                  return _validateNonce.apply(this, arguments);
+                }
+
+                return validateNonce;
+              }()
+            })(req, res);
+
+          case 2:
+            expect(res.end).toHaveBeenCalledWith(JSON.stringify({
+              message: "Invalid Nonce."
+            }));
+
+          case 3:
+          case "end":
+            return _context2.stop();
+        }
+      }
+    }, _callee2);
+  })));
+  test('it passes if validateNonce passes', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee4() {
+    return _regenerator["default"].wrap(function _callee4$(_context4) {
+      while (1) {
+        switch (_context4.prev = _context4.next) {
+          case 0:
+            _context4.next = 2;
+            return (0, _handleAuthCallback["default"])(function (req, res) {}, {
+              validateNonce: function () {
+                var _validateNonce2 = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee3() {
+                  return _regenerator["default"].wrap(function _callee3$(_context3) {
+                    while (1) {
+                      switch (_context3.prev = _context3.next) {
+                        case 0:
+                          return _context3.abrupt("return", true);
+
+                        case 1:
+                        case "end":
+                          return _context3.stop();
+                      }
+                    }
+                  }, _callee3);
+                }));
+
+                function validateNonce() {
+                  return _validateNonce2.apply(this, arguments);
+                }
+
+                return validateNonce;
+              }()
+            })(req, res);
+
+          case 2:
+            expect(res.redirect).toHaveBeenCalledWith('/home?shop=test.myshopify.com');
+
+          case 3:
+          case "end":
+            return _context4.stop();
+        }
+      }
+    }, _callee4);
+  })));
+  test('it redirects to the HOME_PATH by default', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee5() {
+    return _regenerator["default"].wrap(function _callee5$(_context5) {
+      while (1) {
+        switch (_context5.prev = _context5.next) {
+          case 0:
+            _context5.next = 2;
             return (0, _handleAuthCallback["default"])(function (req, res) {})(req, res);
 
           case 2:
@@ -54,17 +139,17 @@ describe('Handling the Shopify OAuth callback response', function () {
 
           case 3:
           case "end":
-            return _context.stop();
+            return _context5.stop();
         }
       }
-    }, _callee);
+    }, _callee5);
   })));
-  test('it redirects to the provided path if the handler returns a custom path with the shop query param appended automatically', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee2() {
-    return _regenerator["default"].wrap(function _callee2$(_context2) {
+  test('it redirects to the provided path if the handler returns a custom path with the shop query param appended automatically', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee6() {
+    return _regenerator["default"].wrap(function _callee6$(_context6) {
       while (1) {
-        switch (_context2.prev = _context2.next) {
+        switch (_context6.prev = _context6.next) {
           case 0:
-            _context2.next = 2;
+            _context6.next = 2;
             return (0, _handleAuthCallback["default"])(function (req, res) {
               return '/a-custom-path';
             })(req, res);
@@ -74,9 +159,9 @@ describe('Handling the Shopify OAuth callback response', function () {
 
           case 3:
           case "end":
-            return _context2.stop();
+            return _context6.stop();
         }
       }
-    }, _callee2);
+    }, _callee6);
   })));
 });

--- a/lib/middleware/oauth/handleAuthStart.js
+++ b/lib/middleware/oauth/handleAuthStart.js
@@ -1,29 +1,79 @@
 "use strict";
 
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
 
+var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
+
+var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
+
 var nonce = require("nonce");
 
 var createNonce = nonce();
 
-var _default = function _default(req, res) {
-  var query = req.body.query;
-  var scopes = process.env.SHOPIFY_AUTH_SCOPES;
-  var redirect_uri = process.env.SHOPIFY_AUTH_CALLBACK_URL;
+var _default = function _default(options) {
+  return /*#__PURE__*/function () {
+    var _ref = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee(req, res) {
+      var query, scopes, redirect_uri, generateNonce, generatedNonce, authUrl;
+      return _regenerator["default"].wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              query = req.body.query;
+              scopes = process.env.SHOPIFY_AUTH_SCOPES;
+              redirect_uri = process.env.SHOPIFY_AUTH_CALLBACK_URL;
+              generateNonce = options && options.generateNonce;
 
-  if (!query.shop) {
-    return res.status(401).json({
-      message: "Unauthorized: Required Query or Shop missing."
-    });
-  }
+              if (!generateNonce) {
+                _context.next = 10;
+                break;
+              }
 
-  var authUrl = "https://".concat(query.shop, "/admin/oauth/authorize?client_id=").concat(process.env.SHOPIFY_API_PUBLIC_KEY, "&scope=").concat(scopes, "&redirect_uri=").concat(redirect_uri, "&state=").concat(createNonce());
-  res.status(200).json({
-    redirectTo: authUrl
-  });
+              _context.next = 7;
+              return generateNonce(req);
+
+            case 7:
+              _context.t0 = _context.sent;
+              _context.next = 11;
+              break;
+
+            case 10:
+              _context.t0 = createNonce();
+
+            case 11:
+              generatedNonce = _context.t0;
+
+              if (query.shop) {
+                _context.next = 14;
+                break;
+              }
+
+              return _context.abrupt("return", res.status(401).json({
+                message: "Unauthorized: Required Query or Shop missing."
+              }));
+
+            case 14:
+              authUrl = "https://".concat(query.shop, "/admin/oauth/authorize?client_id=").concat(process.env.SHOPIFY_API_PUBLIC_KEY, "&scope=").concat(scopes, "&redirect_uri=").concat(redirect_uri, "&state=").concat(generatedNonce);
+              res.status(200).json({
+                redirectTo: authUrl
+              });
+
+            case 16:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+
+    return function (_x, _x2) {
+      return _ref.apply(this, arguments);
+    };
+  }();
 };
 
 exports["default"] = _default;

--- a/src/middleware/oauth/handleAuthCallback.js
+++ b/src/middleware/oauth/handleAuthCallback.js
@@ -2,12 +2,21 @@ import querystring from "querystring";
 import verifyHmac from "./verifyHmac";
 import exchangeAccessToken from './exchangeAccessToken';
 
-export default handler => {
+export default (handler, options) => {
   return async (req, res) => {
+
     const valid = verifyHmac(req.query);
     if (!valid) {
       res.statusCode = 403;
       res.end(JSON.stringify({ message: "Invalid Signature." }));
+      return;
+    }
+
+    const validateNonce = options && options.validateNonce;
+    const validNonce = validateNonce ? await validateNonce(req.query.state, req) : true;
+    if (!validNonce) {
+      res.statusCode = 403;
+      res.end(JSON.stringify({ message: "Invalid Nonce." }));
       return;
     }
 

--- a/src/middleware/oauth/handleAuthCallback.test.js
+++ b/src/middleware/oauth/handleAuthCallback.test.js
@@ -17,6 +17,7 @@ const req = httpMocks.createRequest({
 
 const res = {
   redirect: jest.fn(),
+  end: jest.fn(),
 };
 
 describe('Handling the Shopify OAuth callback response', () => {
@@ -30,6 +31,16 @@ describe('Handling the Shopify OAuth callback response', () => {
 
   afterAll(() => {
     process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('it fails if validateNonce fails', async () => {
+    await handleAuthCallback((req, res) => {}, { validateNonce: async () => false })(req, res);
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({message: "Invalid Nonce."}));
+  });
+
+  test('it passes if validateNonce passes', async () => {
+    await handleAuthCallback((req, res) => {}, { validateNonce: async () => true })(req, res);
+    expect(res.redirect).toHaveBeenCalledWith('/home?shop=test.myshopify.com')
   });
 
   test('it redirects to the HOME_PATH by default', async () => {

--- a/src/middleware/oauth/handleAuthStart.js
+++ b/src/middleware/oauth/handleAuthStart.js
@@ -1,22 +1,28 @@
 const nonce = require("nonce");
 const createNonce = nonce();
 
-export default (req, res) => {
-  const { query } = req.body;
-  const scopes = process.env.SHOPIFY_AUTH_SCOPES;
-  const redirect_uri = process.env.SHOPIFY_AUTH_CALLBACK_URL;
+export default options => {
+  return async (req, res) => {
 
-  if (!query.shop) {
-    return res
-      .status(401)
-      .json({ message: "Unauthorized: Required Query or Shop missing." });
-  }
+    const { query } = req.body;
+    const scopes = process.env.SHOPIFY_AUTH_SCOPES;
+    const redirect_uri = process.env.SHOPIFY_AUTH_CALLBACK_URL;
 
-  const authUrl = `https://${query.shop}/admin/oauth/authorize?client_id=${
-    process.env.SHOPIFY_API_PUBLIC_KEY
-  }&scope=${scopes}&redirect_uri=${redirect_uri}&state=${createNonce()}`;
+    const generateNonce = options && options.generateNonce;
+    const generatedNonce = generateNonce ? await generateNonce(req) : createNonce();
 
-  res.status(200).json({
-    redirectTo: authUrl,
-  });
-};
+    if (!query.shop) {
+      return res
+        .status(401)
+        .json({ message: "Unauthorized: Required Query or Shop missing." });
+    }
+
+    const authUrl = `https://${query.shop}/admin/oauth/authorize?client_id=${
+      process.env.SHOPIFY_API_PUBLIC_KEY
+    }&scope=${scopes}&redirect_uri=${redirect_uri}&state=${generatedNonce}`;
+
+    res.status(200).json({
+      redirectTo: authUrl,
+    });
+  };
+}


### PR DESCRIPTION
First, thanks for providing this library - it has been very helpful!

Shopify recommends that the nonce/state parameter be validated on the OAuth callback to match what was provided at the start of handshake. 

Specifically, the part about the `{nonce}` in Step 2 in the [Shopify Authentication Docs](https://shopify.dev/tutorials/authenticate-with-oauth).

> {nonce}: A randomly selected value provided by your app that is unique for each authorization request. During the OAuth callback, your app must check that this value matches the one you provided during authorization. This mechanism is important for the security of your app.

This PR adds support for this by way of adding an "options" object parameter to the `handleAuthStart` and `handleAuthCallback` functions which can be used for hooks to generate and validate a nonce (or left off to work as it currently does).

To generate your own nonce, provide an async function as an option to `handleAuthStart`:

```javascript
import { handleAuthStart } from 'shopify-nextjs-toolbox';
const generateNonce = async (req) => {
  console.log("generating nonce");
  return 'my-generated-nonce'; //eg. create uniq id in database
};
export default handleAuthStart({generateNonce});
```

To validate the nonce on the callback, provide an async function as an option to `handleAuthCallback`:

```javascript
import { handleAuthCallback } from 'shopify-nextjs-toolbox';
const afterAuth = async(req, res, accessToken) => {
 ...
};
const validateNonce = async (nonce, req) => {
  console.log("validating nonce");
  return nonce === 'my-generated-nonce'; //eg. validate and remove from database
}
export default handleAuthCallback(afterAuth, { validateNonce })
```