### PR TITLE
Fix useApi to not return a new axios instance every render

### DIFF
--- a/src/hooks/useApi.js
+++ b/src/hooks/useApi.js
@@ -1,7 +1,9 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import axios from "axios";
 import { getSessionToken } from "@shopify/app-bridge-utils";
 import { Context as ShopifyAppContext } from "@shopify/app-bridge-react";
+
+const api = axios.create();
 
 /**
  * Creates a axios client that uses Shopify JWT Session Token authentication
@@ -9,19 +11,22 @@ import { Context as ShopifyAppContext } from "@shopify/app-bridge-react";
  * @returns axios
  */
 export default function useApi() {
-  const api = axios.create();
   const app = useContext(ShopifyAppContext);
 
-  api.interceptors.request.use((config) => {
-    return getSessionToken(app)
-      .then((token) => {
-        config.headers["Authorization"] = `Bearer ${token}`;
-        return config;
-      })
-      .catch((err) => {
-        console.log(err);
+  useEffect(() => {
+    if (app) {
+      api.interceptors.request.use((config) => {
+        return getSessionToken(app)
+          .then((token) => {
+            config.headers["Authorization"] = `Bearer ${token}`;
+            return config;
+          })
+          .catch((err) => {
+            console.log(err);
+          });
       });
-  });
+    }
+  }, [app]);
 
   return api;
 }


### PR DESCRIPTION
### Problem

`useApi` creates and returns a new `axios` instance every render. This makes it unusable as a `useEffect` dependency which is unfortunate when working in a project that uses the recommended  [exhaustive-deps](https://github.com/facebook/react/issues/14920) lint rule.

For example:

```
function Component () {
  const api = useApi();
  const [response, setResponse] = useState(false);

  useEffect(() => {
    api.get("/api/verify-token")
    .then((res) => {
      setResponse(res.data);
    });
  }, []);

  ...
}

```

The above code works fine. But in a project that uses `exhaustive-deps`, you will be forced to add in `api` in the array. That is a problem since it triggers never ending API requests.

```
function Component () {
  const api = useApi();
  const [response, setResponse] = useState(false);

  useEffect(() => { // This will be executed every render while also triggering a re-render.
    api.get("/api/verify-token")
    .then((res) => {
      setResponse(res.data);
    });
  }, [api]);

  ...
}

```

The way we deal with this is to just leave out `api` from the dependency array and add `// eslint-disable-next-line react-hooks/exhaustive-deps` above. This does work but is not ideal in my opinion, especially when there are other dependencies that we have to remember to include.

### Solution

`useApi` can just maintain one instance of `axios` and return that one non-changing instance.
